### PR TITLE
Fix EEPROM Bug #47 

### DIFF
--- a/Drivers/Custom/eeprom.cpp
+++ b/Drivers/Custom/eeprom.cpp
@@ -78,6 +78,15 @@ static uint16_t EE_VerifyPageFullyErased(uint32_t Address);
   */
 uint16_t EE_Init(void)
 {
+  /* Copy EEPROM Parameter IDs to the VirtAddVarTab. NOTE: This is not optimal as NB_OF_VAR shall be set to
+   * PERSISTENT_DATA_ENTRIES but this value is not available for a define. NB_OF_VAR is slightly to large because
+   * some IDs in EEPROM_PARAMETER_ID are skipped but easier to implement. */
+  ASSERT(PERSISTENT_DATA_ENTRIES < NB_OF_VAR);
+  for(unsigned int i = 0; i < PERSISTENT_DATA_ENTRIES; i++){
+      ASSERT(PERSISTENT_DATA[i].id < 0xFFFF); // Only ids < 0xFFFF are allowed.
+      VirtAddVarTab[i] = PERSISTENT_DATA[i].id;
+  }
+
   uint16_t PageStatus0 = 6, PageStatus1 = 6;
   uint16_t VarIdx = 0;
   uint16_t EepromStatus = 0, ReadStatus = 0;

--- a/Drivers/Custom/eeprom.h
+++ b/Drivers/Custom/eeprom.h
@@ -54,6 +54,8 @@
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32f4xx_hal.h"
+#include "persistent_data.h"
+#include "my_assert.h"
 
 /* Exported constants --------------------------------------------------------*/
 /* EEPROM emulation firmware error codes */
@@ -103,7 +105,7 @@
 #define PAGE_FULL             ((uint8_t)0x80)
 
 /* Variables' number */
-#define NB_OF_VAR             ((uint8_t)0x03)
+#define NB_OF_VAR             ((uint8_t)EEPROM_PARAMETER_ID_END)
 
 /* Exported types ------------------------------------------------------------*/
 /* Exported macro ------------------------------------------------------------*/


### PR DESCRIPTION
eeprom.c moved to eeprom.cpp. Initialized virtual variables table implemented

## Checklist before merging
- [x] Is the most recent master version merged? Double check with git pull and git merge master.
- [x] Does it compile without errors?
- [x] Has someone reviewed your changes?

### Hardware test
- [x] Flash the ESP and STM Firmware via USB and connect a GNSS antenna
- [x] Test without a SD-Card
- [x] Check that the Bluetooth and CAN works and transmitts data. If possible test with Hardware-version 1.0 and 2.0!
- [x] Insert a SD-Card with the latest sensor_config.txt file from Configuration_files and an empty file named "enable.logger" Let the sensor run for ~ 30 minutes. Afterwards check that there are only two files: data file  yymmdd_hhmmss.f* and a calibration/configuration dump file: yymmdd_hhmmss.EEPROM  There shall be no crash-dump files.

Fix #47 