### PR TITLE
Bugfix: Replace atof() by my_atof()

### DIFF
--- a/sw_stm32/Communication/read_configuration_file.cpp
+++ b/sw_stm32/Communication/read_configuration_file.cpp
@@ -146,7 +146,7 @@ bool read_init_file( const char * filename)
       if( ! is_number_start( *position))
 	continue; // found some form of garbage
 
-      float value = atof( position);
+      float value = my_atof( position);
 
       if( persistent_parameter->is_an_angle)
 	{


### PR DESCRIPTION
The libraries ftoa disbehaves if the input string is terminated by "\r\n".
Additionally, it outputs a double which is inefficient.

We replaced it by a special 32bit version.