### PR TITLE
No CAN / NMEA Output without an inserted uSD card fixed

### DIFF
--- a/sw_stm32/Communication/uSD_handler.cpp
+++ b/sw_stm32/Communication/uSD_handler.cpp
@@ -639,6 +639,7 @@ void uSD_handler_runnable (void*)
 restart:
   // ...just to be sure ...
   ensure_EEPROM_parameter_integrity();
+  delay(1000); //Dirty fix for issue #177
 
   HAL_SD_DeInit (&hsd);
   if(! BSP_PlatformIsDetected())


### PR DESCRIPTION
Workaround for #177. 