### PR TITLE
uSD: publish SD subsystem status flags

### DIFF
--- a/sw_stm32/Communication/uSD_handler.cpp
+++ b/sw_stm32/Communication/uSD_handler.cpp
@@ -49,6 +49,7 @@ COMMON reminder_flag write_configuration_data_now;
 extern Semaphore setup_file_handling_completed;
 
 COMMON bool dump_sensor_readings;
+COMMON uint8_t sensor_sd_status_flags = 0;
 
 COMMON FATFS fatfs;
 extern SD_HandleTypeDef hsd;
@@ -64,6 +65,7 @@ void uSD_handler_runnable (void*)
   make_firmware_digest();
 
 restart:
+  sensor_sd_status_flags = 0;
 
   HAL_SD_DeInit (&hsd);
   if(! BSP_PlatformIsDetected())
@@ -80,6 +82,8 @@ restart:
 	    goto restart;
 	}
     }
+
+  sensor_sd_status_flags |= SENSOR_SD_PRESENT;
 
   delay(500); // ensure that there is some wait time after inserting a sd-card
   HAL_StatusTypeDef hresult = HAL_SD_Init (&hsd);
@@ -107,6 +111,8 @@ restart:
 	  delay(1000);
 	}
     }
+
+  sensor_sd_status_flags |= SENSOR_SD_MOUNTED;
 
   // LED on to signal "uSD active"
   HAL_GPIO_WritePin (LED_STATUS1_GPIO_Port, LED_STATUS2_Pin, GPIO_PIN_SET);
@@ -157,6 +163,7 @@ restart:
 	if( crashfile && ! user_initiated_reset)
 	  write_crash_dump();
 	}
+  sensor_sd_status_flags |= SENSOR_SD_LOGGING_ENABLED;
 
   char out_filename[30];
 
@@ -199,6 +206,7 @@ restart:
 		  write_crash_dump();
 	    }
 	}
+      sensor_sd_status_flags |= SENSOR_SD_FLIGHT_LOG_ACTIVE;
 
       write_configuration_data_now.set();
       unsigned file_sync_counter = 0;
@@ -224,6 +232,7 @@ restart:
 
 	  if( not success)
 	      {
+	      sensor_sd_status_flags &= ~(uint8_t)SENSOR_SD_FLIGHT_LOG_ACTIVE;
 	      flex_file.close(); // at least: try to ...
 
 	      HAL_GPIO_WritePin (LED_STATUS1_GPIO_Port, LED_STATUS2_Pin, GPIO_PIN_RESET);
@@ -239,6 +248,7 @@ restart:
 	    {
 	      flex_file.block_input(); // avoid buffer overrun
 	      flex_file.close();
+	      sensor_sd_status_flags &= ~(uint8_t)SENSOR_SD_FLIGHT_LOG_ACTIVE;
 
 	      delay(250); // just to be sure everything is written
 	      break; /* break inner while loop and start again, which will start a new set of logfiles */

--- a/sw_stm32/Communication/uSD_handler.h
+++ b/sw_stm32/Communication/uSD_handler.h
@@ -10,6 +10,16 @@ extern bool logger_is_enabled;
 extern bool magnetic_gound_calibration;
 extern bool dump_sensor_readings;
 
+enum SensorSdStatusFlags : uint8_t
+{
+  SENSOR_SD_PRESENT = 0x01,
+  SENSOR_SD_MOUNTED = 0x02,
+  SENSOR_SD_LOGGING_ENABLED = 0x04,
+  SENSOR_SD_FLIGHT_LOG_ACTIVE = 0x08
+};
+
+extern uint8_t sensor_sd_status_flags;
+
 extern flexible_log_file_implementation_t flex_file;
 extern reminder_flag perform_after_landing_actions;
 extern reminder_flag write_configuration_data_now;


### PR DESCRIPTION
## Summary

Expose the SD-card subsystem state through a `uint8_t sensor_sd_status_flags`
byte so callers (CAN telemetry, logging, status displays) can observe how
far SD bring-up has progressed without poking into `uSD_handler` internals.

Flags (typed `enum SensorSdStatusFlags : uint8_t` in `uSD_handler.h`):

| Bit  | Name                          | Meaning                                              |
|------|-------------------------------|------------------------------------------------------|
| 0x01 | `SENSOR_SD_PRESENT`           | card detected, controller initialized                |
| 0x02 | `SENSOR_SD_MOUNTED`           | FatFs mounted                                        |
| 0x04 | `SENSOR_SD_LOGGING_ENABLED`   | `logger/` directory present, logging path open      |
| 0x08 | `SENSOR_SD_FLIGHT_LOG_ACTIVE` | a flight log file is currently open                  |

Each bit is set when the corresponding step succeeds and cleared on the
`restart:` path or when the flight log closes. Failure paths that stall
the task indefinitely leave the byte at the last successful state so an
observer can still tell how far bring-up got.

## Why

This is the foundation for surfacing SD subsystem health on telemetry
(CAN frame planned as a follow-up) and for driving UI status indicators
without exposing implementation details of the uSD task.