### PR TITLE
Release tweaks

### DIFF
--- a/sw_stm32/Core/Inc/system_configuration.h
+++ b/sw_stm32/Core/Inc/system_configuration.h
@@ -28,6 +28,7 @@
 #include "persistent_data.h"
 #include "git-commit-version.h"
 
+#define DISALLOW_DOWNGRADE		1
 #define RUN_FLASH_WRITE_TESTER		0
 #define ANALYZE_WRITE_PERFORMANCE	0
 #define MEASURE_WRITE_TIME		0

--- a/sw_stm32/Drivers/Custom/EEPROM_data_file_implementation.cpp
+++ b/sw_stm32/Drivers/Custom/EEPROM_data_file_implementation.cpp
@@ -228,7 +228,8 @@ static bool import_legacy_EEPROM_data( uint32_t * flash_address, unsigned size_w
 	else
 	  result = false;
 
-	result &= (0 != permanent_data_file.store_data ( parameter->id, 1, &value));
+	if( parameter->id != HORIZON)
+	  result &= (0 != permanent_data_file.store_data ( parameter->id, 1, &value));
     }
   return result;
 }


### PR DESCRIPTION
Firmware downgrade disallowed.
Legacy horizon settings replaced by default value 1.1.2000
